### PR TITLE
Adding support for WolkeTokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ $ npm install weeb-sh --save
 
 To use the library you need to obtain a WeebAPI token.
 
+If using a WolkeToken, create the WeebSH instance this way:
+```typescript
+const weebSh = new WeebSH(process.env.WOLKETOKEN, 1);
+```
+
 ### Examples
 
 Get an array of all the current types:
@@ -27,6 +32,7 @@ Get an array of all the current types:
 ```typescript
 import WeebSH from "weeb-sh";
 
+// If using regular tokens
 const weebSh = new WeebSH(process.env.TOKEN);
 
 (async () => {

--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ $ npm install weeb-sh --save
 To use the library you need to obtain a WeebAPI token.
 
 If using a WolkeToken, create the WeebSH instance this way:
+
 ```typescript
-const weebSh = new WeebSH(process.env.WOLKETOKEN, 1);
+import WeebSH, { TokenType } from 'weeb-sh'
+
+const weebSh = new WeebSH(process.env.WOLKE_TOKEN, TokenType.Wolke);
 ```
 
 ### Examples
@@ -32,7 +35,6 @@ Get an array of all the current types:
 ```typescript
 import WeebSH from "weeb-sh";
 
-// If using regular tokens
 const weebSh = new WeebSH(process.env.TOKEN);
 
 (async () => {

--- a/src/weeb-sh.ts
+++ b/src/weeb-sh.ts
@@ -119,9 +119,10 @@ export default class WeebSH {
    * ~~~
    *
    * @param {string} token WeebSH authentication token
+   * @param {number} tokenType 0 for regular token, 1 for WolkeTokens
    * @public
    */
-  public constructor(private token: string) { }
+  public constructor(private token: string, private tokenType?: number) { }
 
   // noinspection JSUnusedGlobalSymbols
   /**
@@ -308,12 +309,13 @@ export default class WeebSH {
    */
   private async request(url: string, params?: object): Promise<any> {
     let response;
+    const authHeader = ((this.tokenType === 1) ? "Wolke " : "Bearer ") + this.token
 
     try {
       response = await axios({
         baseURL: this.baseURL,
         headers: {
-          Authorization: "Bearer " + this.token,
+          Authorization: authHeader,
           "Content-Type": "application/json",
         },
         method: "get",

--- a/src/weeb-sh.ts
+++ b/src/weeb-sh.ts
@@ -99,11 +99,17 @@ export interface TypeParams {
   type: string;
 }
 
+export enum TokenType {
+  Bearer,
+  Wolke
+}
+
 export type UrlParams = TypeParams | TagParams;
 
 // noinspection JSUnusedGlobalSymbols
 export default class WeebSH {
   private baseURL: string = "https://api.weeb.sh";
+  private token: string;
   // noinspection JSUnusedGlobalSymbols
   /**
    * Create a new WeebSH instance using your authentication key.
@@ -118,11 +124,21 @@ export default class WeebSH {
    * const weebSh = new WeebSH(process.env.TOKEN);
    * ~~~
    *
+   * If using WolkeTokens
+   *
+   * ~~~
+   * import WeebSH, { TokenType } from 'weeb-sh'
+   *
+   * const weebSh = new WeebSH(process.env.WOLKE_TOKEN, TokenType.Wolke)
+   * ~~~
+   *
    * @param {string} token WeebSH authentication token
-   * @param {number} tokenType 0 for regular token, 1 for WolkeTokens
+   * @param {number} tokenType Token type, as specified by the TokenType enum
    * @public
    */
-  public constructor(private token: string, private tokenType?: number) { }
+  public constructor(token: string, private tokenType?: TokenType) {
+    this.token = ((tokenType === TokenType.Wolke) ? "Wolke " : "Bearer ") + this.token
+   }
 
   // noinspection JSUnusedGlobalSymbols
   /**
@@ -309,13 +325,12 @@ export default class WeebSH {
    */
   private async request(url: string, params?: object): Promise<any> {
     let response;
-    const authHeader = ((this.tokenType === 1) ? "Wolke " : "Bearer ") + this.token
 
     try {
       response = await axios({
         baseURL: this.baseURL,
         headers: {
-          Authorization: authHeader,
+          Authorization: this.token,
           "Content-Type": "application/json",
         },
         method: "get",

--- a/src/weeb-sh.ts
+++ b/src/weeb-sh.ts
@@ -138,7 +138,7 @@ export default class WeebSH {
    */
   public constructor(token: string, private tokenType?: TokenType) {
     this.token = ((tokenType === TokenType.Wolke) ? "Wolke " : "Bearer ") + this.token
-   }
+  }
 
   // noinspection JSUnusedGlobalSymbols
   /**

--- a/test/weeb-sh.test.ts
+++ b/test/weeb-sh.test.ts
@@ -1,6 +1,11 @@
 import WeebAPI from "../src/weeb-sh"
 
-const weebApi = new WeebAPI(process.env.TOKEN);
+let weebApi
+if (process.env.WOLKETOKEN) {
+  weebApi = new WeebAPI(process.env.WOLKETOKEN, 1);
+} else {
+  weebApi = new WeebAPI(process.env.TOKEN);
+}
 
 describe("Get Types Array", () => {
   it("got data from api", done => {

--- a/test/weeb-sh.test.ts
+++ b/test/weeb-sh.test.ts
@@ -1,8 +1,9 @@
-import WeebAPI from "../src/weeb-sh"
+import WeebAPI, { TokenType } from "../src/weeb-sh"
 
 let weebApi
-if (process.env.WOLKETOKEN) {
-  weebApi = new WeebAPI(process.env.WOLKETOKEN, 1);
+
+if (process.env.WOLKE_TOKEN) {
+  weebApi = new WeebAPI(process.env.WOLKE_TOKEN, TokenType.Wolke);
 } else {
   weebApi = new WeebAPI(process.env.TOKEN);
 }

--- a/weeb-sh.d.ts
+++ b/weeb-sh.d.ts
@@ -92,11 +92,15 @@ export interface TypeParams {
      */
     type: string;
 }
+export declare enum TokenType {
+    Bearer = 0,
+    Wolke = 1,
+}
 export declare type UrlParams = TypeParams | TagParams;
 export default class WeebSH {
-    private token;
     private tokenType;
     private baseURL;
+    private token;
     /**
      * Create a new WeebSH instance using your authentication key.
      *
@@ -110,11 +114,19 @@ export default class WeebSH {
      * const weebSh = new WeebSH(process.env.TOKEN);
      * ~~~
      *
+     * If using WolkeTokens
+     *
+     * ~~~
+     * import WeebSH, { TokenType } from 'weeb-sh'
+     *
+     * const weebSh = new WeebSH(process.env.WOLKE_TOKEN, TokenType.Wolke)
+     * ~~~
+     *
      * @param {string} token WeebSH authentication token
-     * @param {number} tokenType 0 for regular token, 1 for WolkeTokens
+     * @param {number} tokenType Token type, as specified by the TokenType enum
      * @public
      */
-    constructor(token: string, tokenType?: number | undefined);
+    constructor(token: string, tokenType?: TokenType | undefined);
     /**
      * Returns an array containing all the current types in the API.
      *

--- a/weeb-sh.d.ts
+++ b/weeb-sh.d.ts
@@ -95,6 +95,7 @@ export interface TypeParams {
 export declare type UrlParams = TypeParams | TagParams;
 export default class WeebSH {
     private token;
+    private tokenType;
     private baseURL;
     /**
      * Create a new WeebSH instance using your authentication key.
@@ -110,9 +111,10 @@ export default class WeebSH {
      * ~~~
      *
      * @param {string} token WeebSH authentication token
+     * @param {number} tokenType 0 for regular token, 1 for WolkeTokens
      * @public
      */
-    constructor(token: string);
+    constructor(token: string, tokenType?: number | undefined);
     /**
      * Returns an array containing all the current types in the API.
      *


### PR DESCRIPTION
Hey. This PR adds support for WolkeTokens.

I used a number instead of a boolean param just in case AkioTokens, or WolkeTokensV2 become a thing ¯\_(ツ)_/¯

I modified the tests to use WolkeTokens if env.WOLKETOKEN is set, even thought the tests still pass with a 401 response, so I'm not entirely sure this makes sense.

Let me know if any changes are needed.